### PR TITLE
MochigomaAreaクラスの更新

### DIFF
--- a/MochigomaArea.pde
+++ b/MochigomaArea.pde
@@ -10,4 +10,13 @@ class MochigomaArea extends AbstractArea {
       }
     }
   }
+  
+   int getBlankYIndex() {
+    for (int i=this.posY; i<this.posY+this.tate; i++) {
+      AbstractKoma koma = komaList.getKomaFromPlace(this.posX, i);
+      if (koma==null) return i;
+    }
+    return -1;//空きが無い場合
+  }
+
 }


### PR DESCRIPTION
MochigomaAreaクラスに getBlankYIndex() メソッドを追加する．


• getBlankYIndex() メソッドでは，現在のturn(Left=0, Right=1)のteamの持ちゴマエリアを探索し，コマが置いていないマス目のy座標を返す
•ここで，持ちゴマエリアにコマが存在するかどうかはKomaListクラスのインスタンスである komaList.getKomaFromPlace() メソッドを利用する．
•空きが持ちゴマエリアに無い場合は-1を返す．